### PR TITLE
修复空值处理

### DIFF
--- a/server/channel_consume.go
+++ b/server/channel_consume.go
@@ -164,13 +164,13 @@ func (This *consume_channel_obj) sendToServerResult(ToServerInfo *ToServer, plug
 			break
 		}
 	} else {
-		ToServerInfo.Lock()
 		if ToServerInfo.ToServerChan == nil {
+			ToServerInfo.Lock()
 			ToServerInfo.ToServerChan = &ToServerChan{
 				To: make(chan *pluginDriver.PluginDataType, 1000),
 			}
+			ToServerInfo.Unlock()
 		}
-		ToServerInfo.Unlock()
 
 		// Check after initialization
 		if ToServerInfo.ToServerChan == nil || ToServerInfo.ToServerChan.To == nil {

--- a/server/to_server_consume.go
+++ b/server/to_server_consume.go
@@ -463,6 +463,9 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 				if This.QueueMsgCount == 0 {
 					// 在全量任务的时候，有可能是起多个消费者,所以这里要判断一下，是不是只剩下一个消费者，只有一个消费者的时候的时候,再将 chan 关闭
 					if This.ThreadCount == 1 {
+						if This.ToServerChan != nil && This.ToServerChan.To != nil {
+							close(This.ToServerChan.To)
+						}
 						This.ToServerChan = nil
 						This.Status = ""
 					}


### PR DESCRIPTION

channelConsume err: runtime error: invalid memory address or nil pointer dereference goroutine 45 [running]:
runtime/debug.Stack()
	/var/jenkins_home/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.20/go/src/runtime/debug/stack.go:24 +0x65
github.com/brokercap/Bifrost/server.(*Channel).channelConsume.func1()
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel.go:133 +0x45
panic({0x10d7ce0, 0x1c25d00})
	/var/jenkins_home/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.20/go/src/runtime/panic.go:884 +0x213
github.com/brokercap/Bifrost/server.(*consume_channel_obj).sendToServerResult(0xc000584f68, 0xc0004d1b80, 0xc0004aeb60)
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel_consume.go:152 +0x73f
github.com/brokercap/Bifrost/server.(*consume_channel_obj).sendToServerList0(0xc000584f68?, {0xc0004a85d8, 0x1, 0xc000584de0?}, 0xc0004aeb60)
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel_consume.go:315 +0xa9
github.com/brokercap/Bifrost/server.(*consume_channel_obj).sendToServerList(0xc000584f68, {0xc0003f7d40?, 0xb?}, 0xc0004aeb60, 0x1, 0x230)
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel_consume.go:272 +0xab
github.com/brokercap/Bifrost/server.(*consume_channel_obj).consumeChannel(0xc000584f68)
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel_consume.go:219 +0x3a9
github.com/brokercap/Bifrost/server.(*Channel).channelConsume(0xc0002e0d20)
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel.go:139 +0xad
created by github.com/brokercap/Bifrost/server.(*Channel).Start
	/var/jenkins_home/workspace/devops-bifrost-prod/server/channel.go:91 +0x1b2